### PR TITLE
Include submodule with urllib

### DIFF
--- a/src/nile/commands/install.py
+++ b/src/nile/commands/install.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import subprocess
 import sys
-import urllib
+import urllib.request
 
 from nile.constants import TEMP_DIRECTORY
 


### PR DESCRIPTION
This resolves the error: "ModuleNotFoundError: No module named 'urllib.requests'" on first installation.
